### PR TITLE
Refactor and strings

### DIFF
--- a/lexerattempts/c_lexer.py
+++ b/lexerattempts/c_lexer.py
@@ -130,7 +130,7 @@ def tokenize(line:str):
                     second_quote_pos = _rm_line.find('"')
                     if second_quote_pos == -1: #Error
                         tokens.append(Token().error(cursor, ERROR_MESSAGES[ErrorMsgs.MissingQuote]))
-                        return tokens
+                        break
 
                     second_quote = Token().quote(second_quote_pos + cursor+1)
                     tokens.append(first_quote)
@@ -147,7 +147,7 @@ def tokenize(line:str):
                     tokens.append(Token().simple(new_token_type))
                     
                     if new_token_type == TokenType.Comment:
-                        return tokens
+                        break
                     
                     cursor += 2
                     continue
@@ -177,7 +177,7 @@ def tokenize(line:str):
 
         else: # Error
             tokens.append(Token().error(cursor, ERROR_MESSAGES[ErrorMsgs.UnexpectedChar]))
-            return tokens
+            break
 
         cursor += 1
 

--- a/lexerattempts/c_lexer.py
+++ b/lexerattempts/c_lexer.py
@@ -83,7 +83,27 @@ VALID_NUMBER_CHARS = tuple(digits)
 
 class Token:
     def __eq__(self, other):
-        return self.type == other.type
+        if self.type != other.type:
+            return False
+        elif self.type in SINGLE_CHARACTER_SYMBOLS.values():
+            return True
+        elif self.type in MULTIPLE_CHARACTER_SYMBOLS.values():
+            return True
+        elif self.type == TokenType.Error:
+            return self.pos == other.pos and self.msg == other.msg
+        elif self.type == TokenType.Comment:
+            # We don't store the contents of comments, so all comments are equivalent
+            return True
+        elif self.type == TokenType.Number:
+            return self.value == other.value
+        elif self.type == TokenType.Identifier:
+            return self.name == other.name
+        elif self.type == TokenType.String:
+            return self.string == other.string
+        else:
+            # Return False in case we forget to add another case above
+            # if we add another TokenType
+            return False
 
     def __repr__(self):
         return str(self.type)
@@ -174,6 +194,22 @@ def tokenize(line:str):
 
     return tokens
 
+class TokenEqTests(unittest.TestCase):
+    def test_different_tokens(self):
+        self.assertNotEqual(Token().identifier("hola"), Token().identifier("mundo"))
+        self.assertNotEqual(Token().number(123), Token().number(456))
+        self.assertNotEqual(Token().number(1), Token().simple(TokenType.Opr_Plus))
+        self.assertNotEqual(Token().simple(TokenType.Opr_Plus), Token().simple(TokenType.Opr_Min))
+        self.assertNotEqual(Token().string("hola"), Token().string("mundo"))
+        self.assertNotEqual(Token().error(1, "hola"), Token().error(2, "hola"))
+        self.assertNotEqual(Token().error(1, "hola"), Token().error(1, "mundo"))
+
+    def test_equal_tokens(self):
+        self.assertEqual(Token().simple(TokenType.Opr_Plus), Token().simple(TokenType.Opr_Plus))
+        self.assertEqual(Token().number(123), Token().number(123))
+        self.assertEqual(Token().identifier("hola"), Token().identifier("hola"))
+        self.assertEqual(Token().string("hola"), Token().string("hola"))
+        self.assertEqual(Token().error(2, "hola"), Token().error(2, "hola"))
 
 class TokenTests(unittest.TestCase):
     def test_empty_token(self):

--- a/lexerattempts/c_lexer.py
+++ b/lexerattempts/c_lexer.py
@@ -139,6 +139,7 @@ def tokenize(line:str):
 
     while cursor < len(line):
         current_char = line[cursor:cursor +1]
+        next_char = line[cursor + 1:cursor + 2]
 
         if current_char == '"': # Strings
             _rm_line = line[cursor+1:]
@@ -154,9 +155,7 @@ def tokenize(line:str):
             continue
 
         elif current_char in SINGLE_CHARACTER_SYMBOLS.keys():
-            if cursor < len(line): # Double char tokens
-                next_char = line[cursor +1:cursor +2]
-
+            if next_char != '': # Double char tokens
                 if current_char + next_char in MULTIPLE_CHARACTER_SYMBOLS:
                     new_token_type = MULTIPLE_CHARACTER_SYMBOLS[current_char + next_char]
                     tokens.append(Token().simple(new_token_type))

--- a/lexerattempts/c_lexer.py
+++ b/lexerattempts/c_lexer.py
@@ -3,39 +3,39 @@ import unittest, enum
 from string import ascii_letters, digits
 
 class TokenType(enum.Enum):
-    Error =     -1
-    Comment =    0
-    Number =     1
-    Identifier = 2
+    Error       = -1
+    Comment     = 0
+    Number      = 1
+    Identifier  = 2
 
-    Opr_Plus =  3 # +
-    Opr_Min =   4 # -
-    Opr_Star =  5 # *
-    Opr_Slash = 6 # /
-    Opr_Eq =    7 # =
-    Opr_Not =   8 # !
-    Opr_Ter =   9 # ?
+    Opr_Plus    = 3 # +
+    Opr_Min     = 4 # -
+    Opr_Star    = 5 # *
+    Opr_Slash   = 6 # /
+    Opr_Eq      = 7 # =
+    Opr_Not     = 8 # !
+    Opr_Ter     = 9 # ?
 
-    Opr_MThan = 10 # >
-    Opr_LThan = 11 # <
+    Opr_MThan   = 10 # >
+    Opr_LThan   = 11 # <
 
-    Sep_Dot =   12 # .
-    Sep_Comm =  13 # ,
-    Sep_DDot =  14 # :
-    Sep_DCom =  15 # ;
-    Sep_Quote = 16 # "
+    Sep_Dot     = 12 # .
+    Sep_Comm    = 13 # ,
+    Sep_DDot    = 14 # :
+    Sep_DCom    = 15 # ;
+    Sep_Quote   = 16 # "
 
-    Agr_LPar =  17 # (
-    Agr_RPar =  18 # )
+    Agr_LPar    = 17 # (
+    Agr_RPar    = 18 # )
 
-    Opr_PlusEq =  19 # +=
-    Opr_MinEq =   20 # -=
-    Opr_StarEq =  21 # *=
+    Opr_PlusEq  = 19 # +=
+    Opr_MinEq   = 20 # -=
+    Opr_StarEq  = 21 # *=
     Opr_SlashEq = 22 # /=
-    Opr_NotEq =   23 # !=
-    Opr_EqEq =    24 # ==
+    Opr_NotEq   = 23 # !=
+    Opr_EqEq    = 24 # ==
 
-    LArrow = 25 # ->
+    LArrow      = 25 # ->
 
 SINGLE_CHARACTER_SYMBOLS = {
     '+': TokenType.Opr_Plus,

--- a/lexerattempts/c_lexer.py
+++ b/lexerattempts/c_lexer.py
@@ -152,7 +152,6 @@ def tokenize(line:str):
             tokens.append(Token().string(_rm_line[:second_quote_pos]))
 
             cursor += second_quote_pos + 2
-            continue
 
         elif current_char + next_char in MULTIPLE_CHARACTER_SYMBOLS:
             token = Token().simple(MULTIPLE_CHARACTER_SYMBOLS[current_char + next_char])

--- a/lexerattempts/c_lexer.py
+++ b/lexerattempts/c_lexer.py
@@ -103,7 +103,7 @@ class Token:
         self.value = value
         return self
 
-    def indentifier(self, name:str):
+    def identifier(self, name:str):
         self.type = TokenType.Identifier
         self.name = name
         return self
@@ -155,7 +155,7 @@ def tokenize(line:str):
             while cursor < len(line) and line[cursor] in VALID_IDENTIFIER_CHARS:
                 cursor += 1
 
-            tokens.append(Token().indentifier(line[first_pos:cursor]))
+            tokens.append(Token().identifier(line[first_pos:cursor]))
 
         elif current_char in VALID_NUMBER_CHARS:
             first_pos = cursor
@@ -208,7 +208,7 @@ class TokenTests(unittest.TestCase):
 
     def test_identifier_token(self):
         tokens = tokenize('Hola ')
-        expected = [Token().indentifier('Hola')]
+        expected = [Token().identifier('Hola')]
 
         self.assertEqual(tokens, expected)
         self.assertEqual(tokens[0].name, 'Hola')
@@ -250,7 +250,7 @@ class TokenTests(unittest.TestCase):
         tokens = tokenize("1234 ho//la mi nombre es cris #")
         expected = [
             Token().number(1234),
-            Token().indentifier('ho'),
+            Token().identifier('ho'),
             Token().simple(TokenType.Comment),
         ]
 
@@ -259,7 +259,7 @@ class TokenTests(unittest.TestCase):
     def test_general(self):
         tokens = tokenize('Hola, "Esto es un string" -> 123 //')
         expected = [
-            Token().indentifier('Hola'),
+            Token().identifier('Hola'),
             Token().simple(TokenType.Sep_Comm),
             Token().string("Esto es un string"),
             Token().simple(TokenType.LArrow),

--- a/lexerattempts/c_lexer.py
+++ b/lexerattempts/c_lexer.py
@@ -154,7 +154,6 @@ def tokenize(line:str):
 
             tokens.append(Token().simple(TOKEN_SYMBOLS[current_char]))
             cursor += 1
-            continue
 
         elif current_char in VALID_IDENTIFIER_CHARS:
             first_pos = cursor
@@ -162,7 +161,6 @@ def tokenize(line:str):
                 cursor += 1
 
             tokens.append(Token().indentifier(line[first_pos:cursor]))
-            continue
 
         elif current_char in VALID_NUMBER_CHARS:
             first_pos = cursor
@@ -171,11 +169,9 @@ def tokenize(line:str):
 
             num = int(line[first_pos:cursor])
             tokens.append(Token().number(num))
-            continue
 
         elif current_char == ' ':
             cursor += 1
-            continue
 
         else: # Error
             tokens.append(Token().error(cursor, ERROR_MESSAGES[ErrorMsgs.UnexpectedChar]))

--- a/lexerattempts/c_lexer.py
+++ b/lexerattempts/c_lexer.py
@@ -247,7 +247,6 @@ class TokenTests(unittest.TestCase):
         expected = [Token().identifier('Hola')]
 
         self.assertEqual(tokens, expected)
-        self.assertEqual(tokens[0].name, 'Hola')
 
     def test_number_token(self):
         tokens = tokenize('1234')
@@ -270,8 +269,6 @@ class TokenTests(unittest.TestCase):
         expected = [Token().error(0, ERROR_MESSAGES[ErrorMsgs.UnexpectedChar])]
 
         self.assertEqual(tokens, expected)
-        self.assertEqual(tokens[0].pos, 0)
-        self.assertEqual(tokens[0].msg, ERROR_MESSAGES[ErrorMsgs.UnexpectedChar])
 
     def test_double_char_tokens(self):
         symbs = list(MULTIPLE_CHARACTER_SYMBOLS.keys())

--- a/lexerattempts/c_lexer.py
+++ b/lexerattempts/c_lexer.py
@@ -7,7 +7,7 @@ class TokenType(enum.Enum):
     Comment =    0
     Number =     1
     Identifier = 2
-    
+
     Opr_Plus =  3 # +
     Opr_Min =   4 # -
     Opr_Star =  5 # *
@@ -15,7 +15,7 @@ class TokenType(enum.Enum):
     Opr_Eq =    7 # =
     Opr_Not =   8 # !
     Opr_Ter =   9 # ?
-    
+
     Opr_MThan = 10 # >
     Opr_LThan = 11 # <
 
@@ -27,7 +27,7 @@ class TokenType(enum.Enum):
 
     Agr_LPar =  17 # (
     Agr_RPar =  18 # )
-    
+
     Opr_PlusEq =  19 # +=
     Opr_MinEq =   20 # -=
     Opr_StarEq =  21 # *=
@@ -37,7 +37,7 @@ class TokenType(enum.Enum):
 
     LArrow = 25 # ->
 
-TOKEN_SYMBOLS = {
+SINGLE_CHARACTER_SYMBOLS = {
     '+': TokenType.Opr_Plus,
     '-': TokenType.Opr_Min,
     '*': TokenType.Opr_Star,
@@ -55,8 +55,10 @@ TOKEN_SYMBOLS = {
     '"': TokenType.Sep_Quote,
 
     '(': TokenType.Agr_LPar,
-    ')': TokenType.Agr_RPar, 
-    
+    ')': TokenType.Agr_RPar,
+}
+
+MULTIPLE_CHARACTER_SYMBOLS = {
     '+=': TokenType.Opr_PlusEq,
     '-=': TokenType.Opr_MinEq,
     '*=': TokenType.Opr_StarEq,
@@ -64,7 +66,7 @@ TOKEN_SYMBOLS = {
     '!=': TokenType.Opr_NotEq,
     '==': TokenType.Opr_EqEq,
     '->': TokenType.LArrow,
-    '//': TokenType.Comment
+    '//': TokenType.Comment,
 }
 
 class ErrorMsgs(enum.Enum):
@@ -112,15 +114,14 @@ class Token:
         self.pos = pos
         return self
 
-
 def tokenize(line:str):
     tokens = []
     cursor = 0
 
     while cursor < len(line):
         current_char = line[cursor:cursor +1]
-        
-        if current_char in TOKEN_SYMBOLS.keys():
+
+        if current_char in SINGLE_CHARACTER_SYMBOLS.keys():
             if current_char == '"': # Strings
 
                 if cursor < len(line):
@@ -141,18 +142,18 @@ def tokenize(line:str):
 
             elif cursor < len(line): # Double char tokens
                 next_char = line[cursor +1:cursor +2]
-                
-                if current_char + next_char in TOKEN_SYMBOLS:
-                    new_token_type = TOKEN_SYMBOLS[current_char + next_char]
+
+                if current_char + next_char in MULTIPLE_CHARACTER_SYMBOLS:
+                    new_token_type = MULTIPLE_CHARACTER_SYMBOLS[current_char + next_char]
                     tokens.append(Token().simple(new_token_type))
-                    
+
                     if new_token_type == TokenType.Comment:
                         break
-                    
+
                     cursor += 2
                     continue
 
-            tokens.append(Token().simple(TOKEN_SYMBOLS[current_char]))
+            tokens.append(Token().simple(SINGLE_CHARACTER_SYMBOLS[current_char]))
             cursor += 1
 
         elif current_char in VALID_IDENTIFIER_CHARS:
@@ -184,16 +185,16 @@ class TokenTests(unittest.TestCase):
     def test_empty_token(self):
         tokens = tokenize('')
         expected = []
-        
+
         self.assertEqual(tokens, expected)
 
-    def test_single_operator_token(self):
+    def test_single_character_token(self):
         symbs = tuple("+-*/!?=<>.,:;()")
 
         for t in symbs:
             tokens = tokenize(t)
-            expected = [Token().simple(TOKEN_SYMBOLS[t])]
-            
+            expected = [Token().simple(SINGLE_CHARACTER_SYMBOLS[t])]
+
             self.assertEqual(tokens, expected)
 
     def test_multiple_non_ligated_operator_separator_agrupation_tokens(self):
@@ -221,7 +222,7 @@ class TokenTests(unittest.TestCase):
     def test_number_token(self):
         tokens = tokenize('1234')
         expected = [Token().number(1234)]
-        
+
         self.assertEqual(tokens, expected)
 
     def test_quote_tokens(self):
@@ -244,11 +245,11 @@ class TokenTests(unittest.TestCase):
         self.assertEqual(tokens[0].msg, ERROR_MESSAGES[ErrorMsgs.UnexpectedChar])
 
     def test_double_char_tokens(self):
-        symbs = list(TOKEN_SYMBOLS.keys())[17:]
-        
+        symbs = list(MULTIPLE_CHARACTER_SYMBOLS.keys())
+
         for t in symbs:
             tokens = tokenize(t)
-            expected = [Token().simple(TOKEN_SYMBOLS[t])]
+            expected = [Token().simple(MULTIPLE_CHARACTER_SYMBOLS[t])]
 
             self.assertEqual(tokens, expected)
 

--- a/lexerattempts/c_lexer.py
+++ b/lexerattempts/c_lexer.py
@@ -154,18 +154,16 @@ def tokenize(line:str):
             cursor += second_quote_pos + 2
             continue
 
-        elif current_char in SINGLE_CHARACTER_SYMBOLS.keys():
-            if next_char != '': # Double char tokens
-                if current_char + next_char in MULTIPLE_CHARACTER_SYMBOLS:
-                    new_token_type = MULTIPLE_CHARACTER_SYMBOLS[current_char + next_char]
-                    tokens.append(Token().simple(new_token_type))
+        elif current_char + next_char in MULTIPLE_CHARACTER_SYMBOLS:
+            token = Token().simple(MULTIPLE_CHARACTER_SYMBOLS[current_char + next_char])
+            tokens.append(token)
 
-                    if new_token_type == TokenType.Comment:
-                        break
+            if token.type == TokenType.Comment:
+                break
 
-                    cursor += 2
-                    continue
+            cursor += 2
 
+        elif current_char in SINGLE_CHARACTER_SYMBOLS:
             tokens.append(Token().simple(SINGLE_CHARACTER_SYMBOLS[current_char]))
             cursor += 1
 

--- a/lexerattempts/c_lexer.py
+++ b/lexerattempts/c_lexer.py
@@ -153,6 +153,8 @@ def tokenize(line:str):
                     continue
 
             tokens.append(Token().simple(TOKEN_SYMBOLS[current_char]))
+            cursor += 1
+            continue
 
         elif current_char in VALID_IDENTIFIER_CHARS:
             first_pos = cursor
@@ -178,8 +180,6 @@ def tokenize(line:str):
         else: # Error
             tokens.append(Token().error(cursor, ERROR_MESSAGES[ErrorMsgs.UnexpectedChar]))
             break
-
-        cursor += 1
 
     return tokens
 


### PR DESCRIPTION
This pull request has three main things:

* Replace `TokenType.Sep_Quote` by a `TokenType.String` so that string literals like `"foobar"` get tokenized as a single token.  This is a widely-used convention in lexers.  Otherwise, the parser would have to reconstruct the string from individual tokens and whitespace.
* Make `Token.__eq__()` do a full comparison of the token's type and its data.  This makes `Token` feel more like a real type, makes the tests shorter, and will be more useful in the parser.
* Simplify the code in `tokenize()` by refactoring and removing special cases.

May I suggest that you read each commit individually to see how the refactoring was done; it's just a simple transformation in each step.