### PR TITLE
Escaped characters

### DIFF
--- a/lexerattempts/c_lexer.py
+++ b/lexerattempts/c_lexer.py
@@ -113,6 +113,12 @@ class Token:
         s = str(self.type)
         if self.type == TokenType.Error:
             s += ": pos=%s msg=%s" % (self.pos, self.msg)
+        elif self.type == TokenType.Number:
+            s += ": value=%s" % self.value
+        elif self.type == TokenType.Identifier:
+            s += ": name=%s" % self.name
+        elif self.type == TokenType.String:
+            s += ": svalue=%s" % self.svalue
 
         return s
 

--- a/lexerattempts/c_lexer.py
+++ b/lexerattempts/c_lexer.py
@@ -308,7 +308,7 @@ class TokenTests(unittest.TestCase):
         ]
         self.assertEqual(tokens, expected)
 
-        tokens = tokenize('"hola \\"')
+        tokens = tokenize(r'"hola \"')
         expected = [
             Token().error(0, ERROR_MESSAGES[ErrorMsgs.MissingQuote])
         ]
@@ -322,18 +322,18 @@ class TokenTests(unittest.TestCase):
         self.assertEqual(tokens, expected)
 
     def test_string_with_invalid_escape(self):
-        tokens = tokenize('"hola\\q"')
+        tokens = tokenize(r'"hola\q"')
         expected = [
             Token().error(6, ERROR_MESSAGES[ErrorMsgs.InvalidEscape])
         ]
         self.assertEqual(tokens, expected)
 
     def test_string_tokens(self):
-        tokens = tokenize('123 "Hola mundo" "hola \\"mundo\\" \\\\\\\\"')
+        tokens = tokenize(r'123 "Hola mundo" "hola \"mundo\" \\\\"')
         expected = [
             Token().number(123),
             Token().string("Hola mundo"),
-            Token().string('hola "mundo" \\\\'),
+            Token().string(r'hola "mundo" \\'),
         ]
 
         self.assertEqual(tokens, expected)

--- a/lexerattempts/c_lexer.py
+++ b/lexerattempts/c_lexer.py
@@ -1,41 +1,42 @@
 # My lexer attempt
-import unittest, enum
+import unittest
+from enum import Enum, auto
 from string import ascii_letters, digits
 
-class TokenType(enum.Enum):
-    Error       = -1
-    Comment     = 0
-    Number      = 1
-    Identifier  = 2
-    String      = 3
+class TokenType(Enum):
+    Error       = auto()
+    Comment     = auto()
+    Number      = auto()
+    Identifier  = auto()
+    String      = auto()
 
-    Opr_Plus    = 4 # +
-    Opr_Min     = 5 # -
-    Opr_Star    = 6 # *
-    Opr_Slash   = 7 # /
-    Opr_Eq      = 8 # =
-    Opr_Not     = 9 # !
-    Opr_Ter     = 10 # ?
+    Opr_Plus    = auto() # +
+    Opr_Min     = auto() # -
+    Opr_Star    = auto() # *
+    Opr_Slash   = auto() # /
+    Opr_Eq      = auto() # =
+    Opr_Not     = auto() # !
+    Opr_Ter     = auto() # ?
 
-    Opr_MThan   = 11 # >
-    Opr_LThan   = 12 # <
+    Opr_MThan   = auto() # >
+    Opr_LThan   = auto() # <
 
-    Sep_Dot     = 13 # .
-    Sep_Comm    = 14 # ,
-    Sep_DDot    = 15 # :
-    Sep_DCom    = 16 # ;
+    Sep_Dot     = auto() # .
+    Sep_Comm    = auto() # ,
+    Sep_DDot    = auto() # :
+    Sep_DCom    = auto() # ;
 
-    Agr_LPar    = 17 # (
-    Agr_RPar    = 18 # )
+    Agr_LPar    = auto() # (
+    Agr_RPar    = auto() # )
 
-    Opr_PlusEq  = 19 # +=
-    Opr_MinEq   = 20 # -=
-    Opr_StarEq  = 21 # *=
-    Opr_SlashEq = 22 # /=
-    Opr_NotEq   = 23 # !=
-    Opr_EqEq    = 24 # ==
+    Opr_PlusEq  = auto() # +=
+    Opr_MinEq   = auto() # -=
+    Opr_StarEq  = auto() # *=
+    Opr_SlashEq = auto() # /=
+    Opr_NotEq   = auto() # !=
+    Opr_EqEq    = auto() # ==
 
-    LArrow      = 25 # ->
+    LArrow      = auto() # ->
 
 SINGLE_CHARACTER_SYMBOLS = {
     '+': TokenType.Opr_Plus,
@@ -68,10 +69,9 @@ MULTIPLE_CHARACTER_SYMBOLS = {
     '//': TokenType.Comment,
 }
 
-class ErrorMsgs(enum.Enum):
-    UnexpectedChar = 0
-    MissingQuote =   1
-
+class ErrorMsgs(Enum):
+    UnexpectedChar     = auto()
+    MissingQuote       = auto()
 
 ERROR_MESSAGES = {
     ErrorMsgs.UnexpectedChar: "Unexpected Character",


### PR DESCRIPTION
Some more refactoring, and a new feature:

* Don't write enum values by hand; use `auto()` from the enum module.
* Accept strings with quoted characters like `"\""` for `"`, or `"\\"` for `\`.
